### PR TITLE
Adding validators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "validatex",
       "version": "2.0.0-alpha.11",
       "license": "MIT",
       "devDependencies": {

--- a/src/validators.test.ts
+++ b/src/validators.test.ts
@@ -104,9 +104,9 @@ describe('minlength', () => {
  // maxlength validator
 describe('maxlength', () => {
   it('returns error', () => {
-    const length = 3;
-    const expectedError = `Should be no longer than ${length} characters`;
-    expect(maxlength(length)("suku")).toEqual(expectedError);
+    const len = 3;
+    const expectedError = `Should be no longer than ${len} characters`;
+    expect(maxlength(len)("suku")).toEqual(expectedError);
   });
   it('returns undefined', () => {
     expect(maxlength(6)("summit")).toEqual(undefined);

--- a/src/validators.test.ts
+++ b/src/validators.test.ts
@@ -1,7 +1,7 @@
 import { Context } from './types';
-import { dateFormat, email, length, max, maxlength, min, minlength, pattern } from './validators';
+import { email, length, max, maxDate, maxlength, min, minDate, minlength, pattern, validateDate } from './validators';
 
-// Email Validator
+ // Email Validator
 describe('email', () => {
   it('returns error if an email is invalid', () => {
     expect(email()('aninvalid.email')).toEqual('The email is not valid');
@@ -35,7 +35,7 @@ describe('email', () => {
   });
 });
 
-// Length validator
+ // Length validator
 describe('length', () => {
   it('returns error', () => {
     const expectedError = `Should be ${5} characters long`;
@@ -69,11 +69,13 @@ describe('length', () => {
   });
 });
 
-// Pattern validator
+ // Pattern validator
 describe('pattern', () => {
   it('returns error', () => {
-    const expectedError = `Invalid characters in input`;
-    expect(pattern(/^[a-b]/)('z')).toEqual(expectedError);
+    const val = 'z';
+    const option = /^[a-b]/;
+    const expectedError = `The value ${val} doen't match the pattern ${option}`;
+    expect(pattern(option)(val)).toEqual(expectedError);
   });
   it('returns undefined', () => {
     expect(pattern(/^[a-z0-9]*$/)('12ba')).toEqual(undefined);
@@ -84,7 +86,7 @@ describe('pattern', () => {
   });
 })
 
-// minlength validator
+ // minlength validator
 describe('minlength', () => {
   it('returns error', () => {
     const expectedError = `Should be at least ${5} characters long`;
@@ -99,10 +101,10 @@ describe('minlength', () => {
   });
 })
 
-// maxlength validator
+ // maxlength validator
 describe('maxlength', () => {
   it('returns error', () => {
-    const length = 3
+    const length = 3;
     const expectedError = `Should be no longer than ${length} characters`;
     expect(maxlength(length)("suku")).toEqual(expectedError);
   });
@@ -115,55 +117,82 @@ describe('maxlength', () => {
   });
 })
 
-// min validator
+ // min validator
 describe('min', () => {
   it('returns error', () => {
-    const digit = 5;
-    const expectedError = `Should be at least ${digit} digits long`;
-    expect(min(digit)(4037)).toEqual(expectedError);
+    const val = 12
+    const minVal = 15;
+    const expectedError = `The entered value: ${val} should be at greater than ${minVal}`;
+    expect(min(minVal)(val)).toEqual(expectedError);
   });
   it('returns undefined', () => {
-    expect(min(5)(348453)).toEqual(undefined);
+    expect(min(15)(17)).toEqual(undefined);
   });
   it('considers errorMsg', () => {
     const errorMsg = 'Custom error.';
-    expect(min(6, errorMsg)(4037)).toEqual(errorMsg);
+    expect(min(6, errorMsg)(5)).toEqual(errorMsg);
   });
 })
 
-// max validator
+ // max validator
 describe('max', () => {
   it('returns error', () => {
-    const digit = 3;
-    const expectedError = `Should be no longer than ${digit} digits`;
-    expect(max(digit)(4037)).toEqual(expectedError);
+    const val = 15;
+    const maxVal = 12;
+    const expectedError = `The entered value: ${val} should be smaller than ${maxVal}`;
+    expect(max(maxVal)(val)).toEqual(expectedError);
   });
   it('returns undefined', () => {
-    expect(max(6)(348453)).toEqual(undefined);
+    expect(max(6)(4)).toEqual(undefined);
   });
   it('considers errorMsg', () => {
-    const digit = 3;
-    const errorMsg = `There must not be more than ${digit} digits)`;
-    expect(max(digit, errorMsg)(4037)).toEqual(errorMsg);
+    const maxVal = 3;
+    const errorMsg = `Number smaller than ${maxVal} is expected`;
+    expect(max(maxVal, errorMsg)(5)).toEqual(errorMsg);
   });
 })
 
-// date format validator
-describe('dateFormat', () => {
+ // date validator
+describe('validateDate', () => {
   it('returns error', () => {
-    const expectedError = `Doesn't match the date format of MM/DD/YYYY`;
-    expect(dateFormat('MM/DD/YYYY')('13/04/2021')).toEqual(expectedError);
-  });
-  it('returns invalid format error', () => {
-    const expectedError = `Invalid date format specified`;
-    expect(dateFormat('MM/DD/YYY')('12/04/2021')).toEqual(expectedError);
+    const expectedError = `The given date is invalid`;
+    expect(validateDate()(new Date("2021/13/4"))).toEqual(expectedError);
   });
   it('returns undefined', () => {
-    expect(dateFormat('MM/DD/YYYY')('12/05/2021')).toEqual(undefined);
+    expect(validateDate()(new Date("2021-12-5"))).toEqual(undefined);
   });
   it('considers errorMsg', () => {
-    const option = 'YYYY/MM/DD';
-    const errorMsg = `The date entered doesn't match the format ${option}`;
-    expect(dateFormat(option, errorMsg)('04/13/2021')).toEqual(errorMsg);
+    const errorMsg = `The date entered doesn't exist.`;
+    expect(validateDate(errorMsg)(new Date("14/5/2021"))).toEqual(errorMsg);
+  });
+})
+
+ // min date validator
+describe('minDate', () => {
+  it('returns error', () => {
+    const expectedError = `The entered date must come after 2021-4-5`;
+    expect(minDate(new Date("2021/4/5"))(new Date("2021/3/4"))).toEqual(expectedError);
+  });
+  it('returns undefined', () => {
+    expect(minDate(new Date("2021/4/5"))(new Date("2021/4/6"))).toEqual(undefined);
+  });
+  it('considers errorMsg', () => {
+    const errorMsg = `The date entered doesn't exist.`;
+    expect(minDate(new Date("2021/4/5"), errorMsg)(new Date("2020/4/6"))).toEqual(errorMsg);
+  });
+})
+
+ // max date validator
+describe('maxDate', () => {
+  it('returns error', () => {
+    const expectedError = `The entered date must come before 2021-4-5`;
+    expect(maxDate(new Date("2021/4/5"))(new Date("2021/6/4"))).toEqual(expectedError);
+  });
+  it('returns undefined', () => {
+    expect(maxDate(new Date("2021/4/5"))(new Date("2020/5/6"))).toEqual(undefined);
+  });
+  it('considers errorMsg', () => {
+    const errorMsg = `The date entered doesn't exist.`;
+    expect(maxDate(new Date("2021/4/5"), errorMsg)(new Date("2022/4/6"))).toEqual(errorMsg);
   });
 })

--- a/src/validators.test.ts
+++ b/src/validators.test.ts
@@ -1,6 +1,7 @@
 import { Context } from './types';
-import { email, length } from './validators';
+import { dateFormat, email, length, max, maxlength, min, minlength, pattern } from './validators';
 
+// Email Validator
 describe('email', () => {
   it('returns error if an email is invalid', () => {
     expect(email()('aninvalid.email')).toEqual('The email is not valid');
@@ -34,6 +35,7 @@ describe('email', () => {
   });
 });
 
+// Length validator
 describe('length', () => {
   it('returns error', () => {
     const expectedError = `Should be ${5} characters long`;
@@ -66,3 +68,102 @@ describe('length', () => {
     expect(got).toEqual(expectedError);
   });
 });
+
+// Pattern validator
+describe('pattern', () => {
+  it('returns error', () => {
+    const expectedError = `Invalid characters in input`;
+    expect(pattern(/^[a-b]/)('z')).toEqual(expectedError);
+  });
+  it('returns undefined', () => {
+    expect(pattern(/^[a-z0-9]*$/)('12ba')).toEqual(undefined);
+  });
+  it('considers errorMsg', () => {
+    const errorMsg = 'Custom error.';
+    expect(pattern(/^[a-z0-9]*$/, errorMsg)('abc_123')).toEqual(errorMsg);
+  });
+})
+
+// minlength validator
+describe('minlength', () => {
+  it('returns error', () => {
+    const expectedError = `Should be at least ${5} characters long`;
+    expect(minlength(5)("suku")).toEqual(expectedError);
+  });
+  it('returns undefined', () => {
+    expect(minlength(5)("summit")).toEqual(undefined);
+  });
+  it('considers errorMsg', () => {
+    const errorMsg = 'Custom error.';
+    expect(minlength(6, errorMsg)("suku")).toEqual(errorMsg);
+  });
+})
+
+// maxlength validator
+describe('maxlength', () => {
+  it('returns error', () => {
+    const length = 3
+    const expectedError = `Should be no longer than ${length} characters`;
+    expect(maxlength(length)("suku")).toEqual(expectedError);
+  });
+  it('returns undefined', () => {
+    expect(maxlength(6)("summit")).toEqual(undefined);
+  });
+  it('considers errorMsg', () => {
+    const errorMsg = 'Custom error.';
+    expect(maxlength(3, errorMsg)("suku")).toEqual(errorMsg);
+  });
+})
+
+// min validator
+describe('min', () => {
+  it('returns error', () => {
+    const digit = 5;
+    const expectedError = `Should be at least ${digit} digits long`;
+    expect(min(digit)(4037)).toEqual(expectedError);
+  });
+  it('returns undefined', () => {
+    expect(min(5)(348453)).toEqual(undefined);
+  });
+  it('considers errorMsg', () => {
+    const errorMsg = 'Custom error.';
+    expect(min(6, errorMsg)(4037)).toEqual(errorMsg);
+  });
+})
+
+// max validator
+describe('max', () => {
+  it('returns error', () => {
+    const digit = 3;
+    const expectedError = `Should be no longer than ${digit} digits`;
+    expect(max(digit)(4037)).toEqual(expectedError);
+  });
+  it('returns undefined', () => {
+    expect(max(6)(348453)).toEqual(undefined);
+  });
+  it('considers errorMsg', () => {
+    const digit = 3;
+    const errorMsg = `There must not be more than ${digit} digits)`;
+    expect(max(digit, errorMsg)(4037)).toEqual(errorMsg);
+  });
+})
+
+// date format validator
+describe('dateFormat', () => {
+  it('returns error', () => {
+    const expectedError = `Doesn't match the date format of MM/DD/YYYY`;
+    expect(dateFormat('MM/DD/YYYY')('13/04/2021')).toEqual(expectedError);
+  });
+  it('returns invalid format error', () => {
+    const expectedError = `Invalid date format specified`;
+    expect(dateFormat('MM/DD/YYY')('12/04/2021')).toEqual(expectedError);
+  });
+  it('returns undefined', () => {
+    expect(dateFormat('MM/DD/YYYY')('12/05/2021')).toEqual(undefined);
+  });
+  it('considers errorMsg', () => {
+    const option = 'YYYY/MM/DD';
+    const errorMsg = `The date entered doesn't match the format ${option}`;
+    expect(dateFormat(option, errorMsg)('04/13/2021')).toEqual(errorMsg);
+  });
+})

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -55,7 +55,7 @@ export function maxlength(
   errorMsg?: CustomErrMsg<string, number>,
 ) {
   return (val: string, context?: Context) => {
-    const defaultErrorMsg = `Should be at least ${option} characters long`;
+    const defaultErrorMsg = `Should be no longer than ${option} characters`;
     if (option < val.length) {
       return getError({
         errorMsg,
@@ -98,9 +98,116 @@ export function length(
 }
 
 // regex
-// minNum
-// maxNum
+export function pattern(
+  option: RegExp,
+  errorMsg?: CustomErrMsg<string, RegExp>
+){
+  const defaultErrorMsg = 'Invalid characters in input';
+  return(val: string, context?: Context): string | undefined => {
+    return option.test(val)
+      ?undefined
+      :getError({
+        errorMsg,
+        defaultErrorMsg,
+        val,
+        context,
+        option,
+      });
+  }
+}
+
+// validator for minimum no of digits in a number
+export function min(
+  option: number,
+  errorMsg?: CustomErrMsg<number, number>,
+) {
+  return (val: number, context?: Context): string | undefined => {
+    const defaultErrorMsg = `Should be at least ${option} digits long`;
+    const num = val.toString()
+    return num.length < option
+      ? getError({ errorMsg, defaultErrorMsg, val, context, option })
+      : undefined 
+  }
+}
+
+// validator for maximum no of digits in a number
+export function max(
+  option: number,
+  errorMsg?: CustomErrMsg<number, number>,
+) {
+  return (val: number, context?: Context): string | undefined => {
+    const defaultErrorMsg = `Should be no longer than ${option} digits`;
+    const num = val.toString()
+    return num.length > option
+      ? getError({ errorMsg, defaultErrorMsg, val, context, option })
+      : undefined 
+  }
+}
+
 // dateFormat
+export function dateFormat(
+  option: string,
+  errorMsg?: CustomErrMsg<string, string>,
+) {
+  return (val: string, context?: Context): string | undefined => {
+    const defaultErrorMsg = `Doesn't match the date format of ${option}`
+    let dateRegex:RegExp = /^/;
+    let posYear = 0;
+    let posMonth = 0;
+    let posDay = 0;
+
+    switch(option){
+      case "MM/DD/YYYY":
+        dateRegex = /^\d{1,2}\/\d{1,2}\/\d{4}$/;
+        posDay = 1;
+        posYear = 2;
+        break;
+        
+      case "DD/MM/YYYY":
+        dateRegex = /^\d{1,2}\/\d{1,2}\/\d{4}$/;
+        posMonth = 1;
+        posYear = 2;
+        break;
+        
+      case "YYYY/MM/DD":
+        dateRegex = /^\d{4}\/\d{1,2}\/\d{1,2}$/;
+        posMonth = 1;
+        posDay = 2;
+        break;
+
+      default:
+        let defaultErrorMsg = "Invalid date format specified"
+        return getError({ errorMsg, defaultErrorMsg, val, context, option })
+    }
+
+    if (!dateRegex.test(val)) 
+      return getError({ errorMsg, defaultErrorMsg, val, context, option })
+      
+    //Parsing the date part to integers
+    var parts = val.split("/");
+    var day = parseInt(parts[posDay], 10);
+    var month = parseInt(parts[posMonth], 10);
+    var year = parseInt(parts[posYear], 10);
+
+    //Check the ranges of month and year
+    if(year < 1000 || year > 3000 || month == 0 || month > 12)
+      return getError({ errorMsg, defaultErrorMsg, val, context, option })
+
+    var monthLength = [ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ];
+
+    // Adjust for leap years
+    if(year % 400 == 0 || (year % 100 != 0 && year % 4 == 0))
+        monthLength[1] = 29;
+
+    // Check the range of the day
+    if (day > 0 && day <= monthLength[month - 1]){
+      return undefined;
+    }else{
+      return getError({ errorMsg, defaultErrorMsg, val, context, option })
+    }
+  }
+}
+
 // minDate
 // maxDate
 

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -30,7 +30,8 @@ export function getError<T, O>({
   return defaultErrorMsg;
 }
 
-export function minStr(
+//validator for minimum string length
+export function minlength(
   option: number,
   errorMsg?: CustomErrMsg<string, number>,
 ) {
@@ -48,7 +49,8 @@ export function minStr(
   };
 }
 
-export function maxStr(
+//validator for maximum string length
+export function maxlength(
   option: number,
   errorMsg?: CustomErrMsg<string, number>,
 ) {

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,3 +1,4 @@
+import { number } from './decoders';
 import { Decoder, ErrorMsg, Context, TypeOf } from './types';
 
 export type GetErrorMsg<T, O> = ({
@@ -30,7 +31,7 @@ export function getError<T, O>({
   return defaultErrorMsg;
 }
 
-//validator for minimum string length
+ //validator for minimum string length
 export function minlength(
   option: number,
   errorMsg?: CustomErrMsg<string, number>,
@@ -49,7 +50,7 @@ export function minlength(
   };
 }
 
-//validator for maximum string length
+ //validator for maximum string length
 export function maxlength(
   option: number,
   errorMsg?: CustomErrMsg<string, number>,
@@ -102,8 +103,8 @@ export function pattern(
   option: RegExp,
   errorMsg?: CustomErrMsg<string, RegExp>
 ){
-  const defaultErrorMsg = 'Invalid characters in input';
   return(val: string, context?: Context): string | undefined => {
+    const defaultErrorMsg = `The value ${val} doen't match the pattern ${option}`;
     return option.test(val)
       ?undefined
       :getError({
@@ -116,100 +117,153 @@ export function pattern(
   }
 }
 
-// validator for minimum no of digits in a number
+ // validator for minimum no of digits in a number
 export function min(
   option: number,
   errorMsg?: CustomErrMsg<number, number>,
 ) {
   return (val: number, context?: Context): string | undefined => {
-    const defaultErrorMsg = `Should be at least ${option} digits long`;
-    const num = val.toString()
-    return num.length < option
+    const defaultErrorMsg = `The entered value: ${val} should be at greater than ${option}`;
+    return val < option
       ? getError({ errorMsg, defaultErrorMsg, val, context, option })
       : undefined 
   }
 }
 
-// validator for maximum no of digits in a number
+ // validator for maximum no of digits in a number
 export function max(
   option: number,
   errorMsg?: CustomErrMsg<number, number>,
 ) {
   return (val: number, context?: Context): string | undefined => {
-    const defaultErrorMsg = `Should be no longer than ${option} digits`;
-    const num = val.toString()
-    return num.length > option
+    const defaultErrorMsg = `The entered value: ${val} should be smaller than ${option}`;
+    return val > option
       ? getError({ errorMsg, defaultErrorMsg, val, context, option })
       : undefined 
   }
 }
 
-// dateFormat
-export function dateFormat(
-  option: string,
-  errorMsg?: CustomErrMsg<string, string>,
+  // parses day, month and year from the given date
+function parseDate(date: Date): number[] {
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  
+  const parts = date.toString().split(" ");
+  const day = parseInt(parts[2], 10);
+  const month = months.indexOf(parts[1]) + 1;
+  const year = parseInt(parts[3], 10);
+  
+  const dateValue:number[] = [day, month, year];
+  return dateValue;
+}
+
+ // dateFormat
+export function validateDate(
+  errorMsg?: CustomErrMsg<Date, undefined>,
 ) {
-  return (val: string, context?: Context): string | undefined => {
-    const defaultErrorMsg = `Doesn't match the date format of ${option}`
-    let dateRegex:RegExp = /^/;
-    let posYear = 0;
-    let posMonth = 0;
-    let posDay = 0;
+  return (val: Date, context?: Context): string | undefined => {
+    let defaultErrorMsg = `The given date is invalid`
+    
+    const date = parseDate(val);
+    const day = date[0];
+    const month = date[1];
+    const year = date[2];
 
-    switch(option){
-      case "MM/DD/YYYY":
-        dateRegex = /^\d{1,2}\/\d{1,2}\/\d{4}$/;
-        posDay = 1;
-        posYear = 2;
-        break;
-        
-      case "DD/MM/YYYY":
-        dateRegex = /^\d{1,2}\/\d{1,2}\/\d{4}$/;
-        posMonth = 1;
-        posYear = 2;
-        break;
-        
-      case "YYYY/MM/DD":
-        dateRegex = /^\d{4}\/\d{1,2}\/\d{1,2}$/;
-        posMonth = 1;
-        posDay = 2;
-        break;
+     //Check the ranges of month and year
+    if(year < 1000 || year > 3000 || month === 0 || month > 12)
+      return getError({ errorMsg, defaultErrorMsg, val, context, option:undefined })
 
-      default:
-        let defaultErrorMsg = "Invalid date format specified"
-        return getError({ errorMsg, defaultErrorMsg, val, context, option })
-    }
+    const monthLength = [ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ];
 
-    if (!dateRegex.test(val)) 
-      return getError({ errorMsg, defaultErrorMsg, val, context, option })
-      
-    //Parsing the date part to integers
-    var parts = val.split("/");
-    var day = parseInt(parts[posDay], 10);
-    var month = parseInt(parts[posMonth], 10);
-    var year = parseInt(parts[posYear], 10);
-
-    //Check the ranges of month and year
-    if(year < 1000 || year > 3000 || month == 0 || month > 12)
-      return getError({ errorMsg, defaultErrorMsg, val, context, option })
-
-    var monthLength = [ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ];
-
-    // Adjust for leap years
-    if(year % 400 == 0 || (year % 100 != 0 && year % 4 == 0))
+     // Adjust for leap years
+    if(year % 400 === 0 || (year % 100 !== 0 && year % 4 === 0))
         monthLength[1] = 29;
 
-    // Check the range of the day
+     // Check the range of the day
     if (day > 0 && day <= monthLength[month - 1]){
       return undefined;
     }else{
-      return getError({ errorMsg, defaultErrorMsg, val, context, option })
+      return getError({ errorMsg, defaultErrorMsg, val, context, option:undefined })
     }
   }
 }
 
-// minDate
-// maxDate
+ // minDate
+export function minDate(
+  option : Date,
+  errorMsg?: CustomErrMsg<Date, undefined>,
+) {
+  return (val: Date, context?: Context): string | undefined => {
+    const minDate = parseDate(option);
+    const minDay = minDate[0];
+    const minMonth = minDate[1];
+    const minYear = minDate[2];
+
+    const defaultErrorMsg = `The entered date must come after ${minYear}-${minMonth}-${minDay}`
+
+    if (validateDate()(val) !== undefined ){
+      return getError({ errorMsg, defaultErrorMsg, val, context, option:undefined })
+    }
+
+    const date = parseDate(val);
+    const day = date[0];
+    const month = date[1];
+    const year = date[2];
+
+    if (year > minYear){
+      return undefined; 
+    }
+    else if(year === minYear && month > minMonth )
+    {
+      return undefined
+    }
+    else if(year === minYear && month === minMonth && day >= minDay)
+    {
+      return undefined
+    }
+    else{
+      return getError({ errorMsg, defaultErrorMsg, val, context, option:undefined })
+    }
+  }
+}
+
+ // maxDate
+export function maxDate(
+  option : Date,
+  errorMsg?: CustomErrMsg<Date, undefined>,
+) {
+  return (val: Date, context?: Context): string | undefined => {
+    const maxDate = parseDate(option);
+    const maxDay = maxDate[0];
+    const maxMonth = maxDate[1];
+    const maxYear = maxDate[2];
+
+    const defaultErrorMsg = `The entered date must come before ${maxYear}-${maxMonth}-${maxDay}`
+
+    if (validateDate()(val) !== undefined ){
+      return getError({ errorMsg, defaultErrorMsg, val, context, option:undefined })
+    }
+
+    const date = parseDate(val);
+    const day = date[0];
+    const month = date[1];
+    const year = date[2];
+
+    if (year < maxYear){
+      return undefined; 
+    }
+    else if(year === maxYear && month < maxMonth )
+    {
+      return undefined
+    }
+    else if(year === maxYear && month === maxMonth && day <= maxDay)
+    {
+      return undefined
+    }
+    else{
+      return getError({ errorMsg, defaultErrorMsg, val, context, option:undefined })
+    }
+  }
+}
 
 export type ValidationSuccess<T> = { success: true; data: T };
 export type ValidationFailure = { success: false; error: ErrorMsg };

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -31,7 +31,7 @@ export function getError<T, O>({
   return defaultErrorMsg;
 }
 
- //validator for minimum string length
+ // validator for minimum string length
 export function minlength(
   option: number,
   errorMsg?: CustomErrMsg<string, number>,
@@ -50,7 +50,7 @@ export function minlength(
   };
 }
 
- //validator for maximum string length
+ // validator for maximum string length
 export function maxlength(
   option: number,
   errorMsg?: CustomErrMsg<string, number>,
@@ -161,14 +161,14 @@ export function validateDate(
   errorMsg?: CustomErrMsg<Date, undefined>,
 ) {
   return (val: Date, context?: Context): string | undefined => {
-    let defaultErrorMsg = `The given date is invalid`
+    const defaultErrorMsg = `The given date is invalid`
     
     const date = parseDate(val);
     const day = date[0];
     const month = date[1];
     const year = date[2];
 
-     //Check the ranges of month and year
+     // Check the ranges of month and year
     if(year < 1000 || year > 3000 || month === 0 || month > 12)
       return getError({ errorMsg, defaultErrorMsg, val, context, option:undefined })
 
@@ -193,10 +193,10 @@ export function minDate(
   errorMsg?: CustomErrMsg<Date, undefined>,
 ) {
   return (val: Date, context?: Context): string | undefined => {
-    const minDate = parseDate(option);
-    const minDay = minDate[0];
-    const minMonth = minDate[1];
-    const minYear = minDate[2];
+    const minimum = parseDate(option);
+    const minDay = minimum[0];
+    const minMonth = minimum[1];
+    const minYear = minimum[2];
 
     const defaultErrorMsg = `The entered date must come after ${minYear}-${minMonth}-${minDay}`
 
@@ -232,10 +232,10 @@ export function maxDate(
   errorMsg?: CustomErrMsg<Date, undefined>,
 ) {
   return (val: Date, context?: Context): string | undefined => {
-    const maxDate = parseDate(option);
-    const maxDay = maxDate[0];
-    const maxMonth = maxDate[1];
-    const maxYear = maxDate[2];
+    const maximum = parseDate(option);
+    const maxDay = maximum[0];
+    const maxMonth = maximum[1];
+    const maxYear = maximum[2];
 
     const defaultErrorMsg = `The entered date must come before ${maxYear}-${maxMonth}-${maxDay}`
 


### PR DESCRIPTION
I've added 4 validators:
1) pattern: validator for regex
2) min: minimum length validator for numbers
3) max: maximum length validator for numbers
4) dateFormat: validator that checks the format of the date. Available formats ("MM/DD/YYYY", "DD/MM/YYYY", "YYYY/MM/DD")

Changed some names of the validators:
minStr -> minlength
maxStr -> maxlength

Tested all the mentioned validators for all the conditions except for "considers getErrorMsg";